### PR TITLE
ExistingClaims +  nodeselector + multiple CVMFS-CSI deployments co-existing

### DIFF
--- a/galaxy-cvmfs-csi/templates/cache-pvcs.yaml
+++ b/galaxy-cvmfs-csi/templates/cache-pvcs.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.cache.alienCache.enabled }}
+{{- if not .Values.cache.alienCache.existingClaim }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -16,8 +17,10 @@ spec:
   resources:
     requests:
       storage: {{ .Values.cache.alienCache.size }}Mi
+{{ end -}}
 {{ else -}}
 {{- if .Values.cache.localCache.enabled }}
+{{- if not .Values.cache.localCache.existingClaim }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -35,5 +38,6 @@ spec:
   resources:
     requests:
       storage: {{ .Values.cache.localCache.size }}Mi
+{{ end -}}
 {{ end -}}
 {{ end -}}

--- a/galaxy-cvmfs-csi/templates/csi-attacher-rbac.yaml
+++ b/galaxy-cvmfs-csi/templates/csi-attacher-rbac.yaml
@@ -12,7 +12,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cvmfs-external-attacher-runner
+  name: {{include "cvmfs-csi.fullname" .}}-cvmfs-external-attacher-runner
   labels:
     app.kubernetes.io/name: {{ include "cvmfs-csi.name" . }}
     helm.sh/chart: {{ include "cvmfs-csi.chart" . }}
@@ -36,7 +36,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cvmfs-attacher-role
+  name: {{include "cvmfs-csi.fullname" .}}-cvmfs-attacher-role
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "cvmfs-csi.name" . }}
@@ -49,5 +49,5 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: cvmfs-external-attacher-runner
+  name: {{include "cvmfs-csi.fullname" .}}-cvmfs-external-attacher-runner
   apiGroup: rbac.authorization.k8s.io

--- a/galaxy-cvmfs-csi/templates/csi-cvmfsplugin.yaml
+++ b/galaxy-cvmfs-csi/templates/csi-cvmfsplugin.yaml
@@ -18,7 +18,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app: csi-cvmfsplugin
     spec:
-      serviceAccount: cvmfs-nodeplugin
+      serviceAccount: {{include "cvmfs-csi.fullname" .}}-cvmfs-nodeplugin
       hostNetwork: true
       containers:
         - name: csi-driver-registrar

--- a/galaxy-cvmfs-csi/templates/csi-cvmfsplugin.yaml
+++ b/galaxy-cvmfs-csi/templates/csi-cvmfsplugin.yaml
@@ -111,16 +111,30 @@ spec:
         {{- fail "Only one of alien or local cache should be enabled."}}
         {{- end }}
         {{- if .Values.cache.alienCache.enabled }}
+        {{- if .Values.cache.alienCache.existingClaim }}
+        - name: cvmfs-alien-cache
+          persistentVolumeClaim:
+            claimName: {{ .Values.cache.alienCache.existingClaim }}
+        - name: cvmfs-local-cache
+          emptyDir: {}
+        {{- else }}
         - name: cvmfs-alien-cache
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-cvmfs-alien-cache-pvc
         - name: cvmfs-local-cache
           emptyDir: {}
+        {{- end }}
         {{- else }}
         {{- if .Values.cache.localCache.enabled }}
+        {{- if .Values.cache.localCache.existingClaim }}
+        - name: cvmfs-local-cache
+          persistentVolumeClaim:
+            claimName: {{ .Values.cache.localCache.existingClaim }}
+        {{- else }}
         - name: cvmfs-local-cache
           persistentVolumeClaim:
             claimName: {{ .Release.Name }}-cvmfs-local-cache-pvc
+        {{- end }}
         {{- else }}
         - name: {{ .Release.Name }}-cvmfs-local-cache-pvc
           emptyDir: {}

--- a/galaxy-cvmfs-csi/templates/csi-nodeplugin-rbac.yaml
+++ b/galaxy-cvmfs-csi/templates/csi-nodeplugin-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cvmfs-nodeplugin
+  name: {{include "cvmfs-csi.fullname" .}}-cvmfs-nodeplugin
   labels:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -9,7 +9,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cvmfs-nodeplugin
+  name: {{include "cvmfs-csi.fullname" .}}-cvmfs-nodeplugin
   labels:
     app.kubernetes.io/name: {{ include "cvmfs-csi.name" . }}
     helm.sh/chart: {{ include "cvmfs-csi.chart" . }}
@@ -32,7 +32,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cvmfs-nodeplugin
+  name: {{include "cvmfs-csi.fullname" .}}-cvmfs-nodeplugin
   labels:
     app.kubernetes.io/name: {{ include "cvmfs-csi.name" . }}
     helm.sh/chart: {{ include "cvmfs-csi.chart" . }}
@@ -40,11 +40,11 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 subjects:
   - kind: ServiceAccount
-    name: cvmfs-nodeplugin
+    name: {{include "cvmfs-csi.fullname" .}}-cvmfs-nodeplugin
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: cvmfs-nodeplugin
+  name: {{include "cvmfs-csi.fullname" .}}-cvmfs-nodeplugin
   apiGroup: rbac.authorization.k8s.io
 
   

--- a/galaxy-cvmfs-csi/templates/csi-provisioner-rbac.yaml
+++ b/galaxy-cvmfs-csi/templates/csi-provisioner-rbac.yaml
@@ -11,7 +11,7 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cvmfs-provisioner-runner
+  name: {{include "cvmfs-csi.fullname" .}}-cvmfs-provisioner-runner
   labels:
     app.kubernetes.io/name: {{ include "cvmfs-csi.name" . }}
     helm.sh/chart: {{ include "cvmfs-csi.chart" . }}
@@ -38,7 +38,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: cvmfs-provisioner-role
+  name: {{include "cvmfs-csi.fullname" .}}-cvmfs-provisioner-role
   labels:
     app.kubernetes.io/name: {{ include "cvmfs-csi.name" . }}
     helm.sh/chart: {{ include "cvmfs-csi.chart" . }}
@@ -50,5 +50,5 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: cvmfs-provisioner-runner
+  name: {{include "cvmfs-csi.fullname" .}}-cvmfs-provisioner-runner
   apiGroup: rbac.authorization.k8s.io

--- a/galaxy-cvmfs-csi/values.yaml
+++ b/galaxy-cvmfs-csi/values.yaml
@@ -98,11 +98,12 @@ configs:
   #     -----END PUBLIC KEY-----
 
 # A storage class will be created for each repository
-repositories:
+repositories: {}
   # The key will be used for the storage class name
   # The value will be used for the repository
-  cvmfs-gxy-data: data.galaxyproject.org
-  cvmfs-gxy-cloud: cloud.galaxyproject.org
+
+  #cvmfs-gxy-cloud: cloud.galaxyproject.org
+  # cvmfs-gxy-data: data.galaxyproject.org
   # cvmfs-gxy-main: main.galaxyproject.org
 #  cvmfs-gxy-sandbox: sandbox.galaxyproject.org
 #  cvmfs-gxy-test: test.galaxyproject.org

--- a/galaxy-cvmfs-csi/values.yaml
+++ b/galaxy-cvmfs-csi/values.yaml
@@ -122,6 +122,7 @@ cache:
     # size in Mi, will propagate to both default.local and PV/PVC size
     size: 10000
     mountPath: /mnt/cvmfs/localcache
+    # existingClaim: existing-claim
   # Optional shared ReadWriteMany cache volume.
   # If alien cache is enabled, local cache must be disabled.
   # An emptyDir ephemeral volume will be used for local
@@ -135,6 +136,7 @@ cache:
     size: 10000 # in Mi
     storageClass: nfs
     mountPath: /mnt/cvmfs/aliencache
+    # existingClaim: existing-claim
   preload:
     enabled: false
     repositories:


### PR DESCRIPTION
This makes it possible to have a single CVMFS-CSI per namespace. I thought that's better than using release name and opening up the possibility of multiple per namespace.