### PR TITLE
Only package if the PR was merged, not simply closed.

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -4,6 +4,7 @@ on:
     types: [closed]
 jobs:
   package:
+    if: github.event.pull_request.merged == true
     name: Package and push
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -8,6 +8,12 @@ jobs:
     name: Package and push
     runs-on: ubuntu-latest
     steps:
+      - name: Require a label and version bump to package and release
+        uses: mheap/github-action-required-labels@v2
+        with:
+          mode: exactly
+          count: 1
+          labels: "major,minor,patch"
       - uses: actions/checkout@v2
         with:
            persist-credentials: false


### PR DESCRIPTION
The current action performs a release when a PR is closed, even if the PR was not merged.  This PR adds a check that ensures the PR was also merged.

We should probably just edit the job in the master branch so this PR doesn't cause a spurious release.
