### PR TITLE
Parameterize the name of the storage class created.

### DIFF
--- a/galaxy-cvmfs-csi/templates/storageclass.yaml
+++ b/galaxy-cvmfs-csi/templates/storageclass.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: {{ $.Release.Name }}-cvmfs
+  name: {{ tpl .Values.storageClassName . }}
   labels:
     {{- include "galaxy-cvmfs-csi.labels" $ | nindent 4 }}
 provisioner: cvmfs.csi.cern.ch

--- a/galaxy-cvmfs-csi/values.yaml
+++ b/galaxy-cvmfs-csi/values.yaml
@@ -5,6 +5,8 @@
 # All contents will be run through tpl
 # All mountPaths are relative to /etc/cvmfs/
 
+storageClassName: "{{ .Release.Name }}-cvmfs"
+
 cvmfscsi:
   cvmfsConfig:
     config.d:


### PR DESCRIPTION
If this CSI driver is installed independently, i.e. not with the `galaxy-helm` chart, the default name generated for the storage class is a little redundant.  This PR allows users to specify the name for the storage class.