### PR TITLE
Update chart repo and version for the cvmfs-csi

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -7,7 +7,7 @@ jobs:
     name: Package and push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
            persist-credentials: false
       - uses: cloudve/helm-ci@master

--- a/galaxy-cvmfs-csi/Chart.yaml
+++ b/galaxy-cvmfs-csi/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
-appVersion: "2.2.0"
+appVersion: "2.3.2"
 description: A Helm chart to deploy the CVMFS-CSI Plugin with a pre-built configuration for Galaxy repositories
 name: galaxy-cvmfs-csi
 version: 2.2.0
 icon: https://galaxyproject.org/images/galaxy-logos/galaxy_project_logo_square.png
 dependencies:
   - name: cvmfs-csi
-    repository: https://registry.cern.ch/chartrepo/cern
-    version: 2.2.0
+    repository: oci://registry.cern.ch/kubernetes/charts
+    version: 2.3.2
     alias: cvmfscsi


### PR DESCRIPTION
The URL for the `cvmfs-csi` has changed and the latest (2.3.2) resolves problems when the nodeplugin attempts to automount cvmfs after a restart.

Closes #23 